### PR TITLE
feat: support multidex APKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out/
 build/
 .gradle/
 .kotlin/
+local.properties
+.idea/

--- a/kotlin/android/server/core/src/main/kotlin/com/squareup/stoic/android/server/StoicPluginServer.kt
+++ b/kotlin/android/server/core/src/main/kotlin/com/squareup/stoic/android/server/StoicPluginServer.kt
@@ -138,13 +138,13 @@ class StoicPluginServer(
       val plugin = if (startPlugin.pluginSha != null) {
         val parentClassLoader = StoicPluginServer::class.java.classLoader
         val pluginDir = "$stoicDir/plugin-by-sha/${startPlugin.pluginSha}"
-        val pluginJar = File("$pluginDir/${startPlugin.pluginName}.dex.jar")
-        if (!pluginJar.exists()) {
+        val pluginApk = File("$pluginDir/${startPlugin.pluginName}.apk")
+        if (!pluginApk.exists()) {
           writer.writeResponse(
             startPluginRequestId,
             Failed(
               FailureCode.PLUGIN_MISSING.value,
-              "$pluginJar not loaded"
+              "$pluginApk not loaded"
             )
           )
           return false
@@ -152,12 +152,12 @@ class StoicPluginServer(
 
         val dexoutDir = File("$pluginDir/${startPlugin.pluginName}-dexout")
         dexoutDir.mkdirs()
-        Log.d("stoic", "Making classLoader: (pluginJar: $pluginJar, dexoutDir: $dexoutDir)")
+        Log.d("stoic", "Making classLoader: (pluginApk: $pluginApk, dexoutDir: $dexoutDir)")
 
         // It's important to use canonical paths to avoid triggering
         // https://github.com/square/stoic/issues/2
         val classLoader = DexClassLoader(
-          pluginJar.canonicalPath,
+          pluginApk.canonicalPath,
           dexoutDir.canonicalPath,
           null,
           parentClassLoader)
@@ -288,9 +288,9 @@ class StoicPluginServer(
     }
 
     pluginByShaDir.mkdirs()
-    val pluginJar = File(pluginByShaDir, "${loadPlugin.pluginName}.dex.jar")
-    pluginJar.writeBytes(loadPluginBytes)
-    pluginJar.setWritable(false)
+    val pluginApk = File(pluginByShaDir, "${loadPlugin.pluginName}.apk")
+    pluginApk.writeBytes(loadPluginBytes)
+    pluginApk.setWritable(false)
     writer.writeResponse(requestId, Succeeded("Load plugin succeeded"))
   }
 

--- a/kotlin/common/src/main/kotlin/com/squareup/stoic/common/StoicMessages.kt
+++ b/kotlin/common/src/main/kotlin/com/squareup/stoic/common/StoicMessages.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.Json
 import java.io.DataInputStream
 import java.io.DataOutputStream
 
-const val STOIC_PROTOCOL_VERSION = 4
+const val STOIC_PROTOCOL_VERSION = 5
 const val STDIN = 0
 const val STDOUT = 1
 const val STDERR = 2

--- a/kotlin/host/main/src/main/kotlin/com/squareup/stoic/host/main/DexJarCache.kt
+++ b/kotlin/host/main/src/main/kotlin/com/squareup/stoic/host/main/DexJarCache.kt
@@ -2,21 +2,23 @@
 
 package com.squareup.stoic.host.main
 
+import com.squareup.stoic.bridge.StoicProperties
 import com.squareup.stoic.common.LogLevel
 import com.squareup.stoic.common.PithyException
 import com.squareup.stoic.common.Sha
 import com.squareup.stoic.common.logBlock
 import com.squareup.stoic.common.logInfo
-import com.squareup.stoic.d8pm.d8PreserveManifest
 import kotlinx.serialization.ExperimentalSerializationApi
 import java.io.File
+import java.io.FileInputStream
 import java.nio.file.*
 import java.nio.file.attribute.FileTime
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
 import java.io.FileOutputStream
-import java.util.zip.ZipFile
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
@@ -24,11 +26,11 @@ import kotlin.io.path.readBytes
 import kotlin.io.path.readText
 
 object DexJarCache {
-  private const val VERSION = 1
+  private const val VERSION = 2
 
   /** Root directory (${java.io.tmpdir}/dex_cache) **/
   private val cacheRoot: Path =
-    Paths.get(System.getProperty("java.io.tmpdir"), ".stoic/cache/jar-$VERSION")
+    Paths.get(System.getProperty("java.io.tmpdir"), ".stoic/cache/apk-$VERSION")
 
   init {
     Files.createDirectories(cacheRoot)
@@ -37,103 +39,96 @@ object DexJarCache {
   fun resolve(jarOrApkFile: File): Pair<File, String> {
     val keyDir = computeKeyDir(jarOrApkFile)
     get(keyDir, jarOrApkFile)?.let { return it }
-    logInfo { "DexJarCache.get failed - regenerating sha/dex" }
+    logInfo { "DexJarCache.get failed - regenerating sha/apk" }
 
-    val dexJar = computeCachedDexJarPath(keyDir, jarOrApkFile)
+    val apk = computeCachedApkPath(keyDir, jarOrApkFile)
     Files.createDirectories(keyDir)
     val metaFile = keyDir.resolve("meta")
     metaFile.deleteIfExists()
 
     if (jarOrApkFile.extension == "apk") {
-      val apkFile = jarOrApkFile
-      logBlock(LogLevel.INFO, { "extracting classes.dex from $jarOrApkFile" }) {
-        // TODO: This doesn't support multidex
-        ZipFile(apkFile).use { zip ->
-          val entry = zip.entries().asSequence().find { it.name.endsWith("classes.dex") }
-          val entry2 = zip.entries().asSequence().find { it.name.endsWith("classes2.dex") }
-          if (entry2 != null) {
-            throw PithyException("Stoic does not yet support multidex - please file an issue")
-          }
-
-          if (entry != null) {
-            zip.getInputStream(entry).use { input ->
-              FileOutputStream(dexJar.toFile()).use { output ->
-                input.copyTo(output)
-              }
-            }
-          } else {
-            throw PithyException("No classes.jar found in ${apkFile.name}")
-          }
-        }
-      }
+      jarOrApkFile.copyTo(apk.toFile(), overwrite = true)
     } else {
-      val jarFile = jarOrApkFile
-      if (dexJar.toFile().canonicalPath != jarFile.canonicalPath) {
-        // The input jarFile is not a .dex.jar
-        dexJar.deleteIfExists()
-        val tmpDir = createTempDirectory("stoic-plugin-").toFile()
-        // TODO: show a status line here - this can take a few seconds if the jar is big
-        logBlock(LogLevel.INFO, { "dexing $jarFile" }) {
-          d8PreserveManifest(jarFile, dexJar.toFile(), tmpDir)
+      jarToApk(jarOrApkFile, apk.toFile())
+    }
+
+    val apkSha256Sum = updateMeta(keyDir, jarOrApkFile)
+    return Pair(apk.toFile(), apkSha256Sum)
+  }
+
+  private fun jarToApk(jarFile: File, apkFile: File) {
+    logBlock(LogLevel.INFO, { "dexing $jarFile to $apkFile" }) {
+      val dexOutDir = createTempDirectory("stoic-dex").toFile()
+      val androidBuildToolsVersion = StoicProperties.ANDROID_BUILD_TOOLS_VERSION
+      val androidHome = System.getenv("ANDROID_HOME") ?: error("Need to set ANDROID_HOME")
+      val d8Path = File("$androidHome/build-tools/$androidBuildToolsVersion/d8")
+
+      check(
+        ProcessBuilder(
+          d8Path.absolutePath,
+          "--min-api", StoicProperties.ANDROID_MIN_SDK.toString(),
+          "--output", dexOutDir.absolutePath,
+          jarFile.absolutePath
+        ).redirectError(ProcessBuilder.Redirect.INHERIT).start().waitFor() == 0
+      ) { "d8 failed" }
+
+      ZipOutputStream(FileOutputStream(apkFile)).use { zipOut ->
+        dexOutDir.listFiles()?.forEach { file ->
+          zipOut.putNextEntry(ZipEntry(file.name))
+          FileInputStream(file).use { it.copyTo(zipOut) }
+          zipOut.closeEntry()
         }
       }
     }
-
-    val dexJarSha256Sum = updateMeta(keyDir, jarOrApkFile)
-    return Pair(dexJar.toFile(), dexJarSha256Sum)
   }
 
   /**
-   * Return the cached dex.jar for [jarFile] if present *and* still valid.
+   * Return the cached apk for [jarOrApkFile] if present *and* still valid.
    * Returns `null` on cache miss.
    */
-  private fun get(keyDir: Path, jarFile: File): Pair<File, String>? {
+  private fun get(keyDir: Path, jarOrApkFile: File): Pair<File, String>? {
     val metaFile = keyDir.resolve("meta")
     if (!metaFile.exists()) {
       return null
     }
 
-    val meta = Json.decodeFromString<DexJarCacheMeta>(metaFile.readText())
-    val dexJar = computeCachedDexJarPath(keyDir, jarFile)
+    val meta = Json.decodeFromString<ApkCacheMeta>(metaFile.readText())
+    val apk = computeCachedApkPath(keyDir, jarOrApkFile)
     val currentCTime = retrieveCTime(Paths.get(meta.canonicalPath))
     if (currentCTime == meta.posixCTime) {
-      return Pair(dexJar.toFile(), meta.dexJarSha256Sum)
+      return Pair(apk.toFile(), meta.apkSha256Sum)
     } else {
       return null
     }
   }
 
-  private fun computeCachedDexJarPath(keyDir: Path, jarFile: File): Path {
-    val canonicalPath = jarFile.canonicalPath
+  private fun computeCachedApkPath(keyDir: Path, jarOrApkFile: File): Path {
+    val canonicalPath = jarOrApkFile.canonicalPath
     val canonicalFile = File(canonicalPath)
-    if (canonicalFile.name.endsWith(".dex.jar")) {
-      return jarFile.toPath()
-    } else {
-      return keyDir.resolve("${canonicalFile.nameWithoutExtension}.dex.jar")
-    }
+    return keyDir.resolve("${canonicalFile.nameWithoutExtension}.apk")
   }
 
-  private fun updateMeta(keyDir: Path, jarFile: File): String {
-    val dexJar = computeCachedDexJarPath(keyDir, jarFile)
-    check(dexJar.exists())
+  private fun updateMeta(keyDir: Path, jarOrApkFile: File): String {
+    val apk = computeCachedApkPath(keyDir, jarOrApkFile)
+    check(apk.exists())
 
-    val canonicalPath = jarFile.canonicalPath
+    val canonicalPath = jarOrApkFile.canonicalPath
     val posixCTime = retrieveCTime(Paths.get(canonicalPath))
-    val dexJarSha256Sum = Sha.computeSha256Sum(dexJar.readBytes())
+    val apkSha256Sum = Sha.computeSha256Sum(apk.readBytes())
 
     val metaFile = keyDir.resolve("meta")
     FileOutputStream(metaFile.toFile()).use {
       Json.encodeToStream(
-        DexJarCacheMeta(
+        ApkCacheMeta(
           canonicalPath = canonicalPath,
           posixCTime = posixCTime,
-          dexJarSha256Sum = dexJarSha256Sum,
+          apkSha256Sum = apkSha256Sum,
         ),
         it
       )
     }
 
-    return dexJarSha256Sum
+    return apkSha256Sum
   }
 
   fun computeKeyDir(jar: File): Path {
@@ -150,9 +145,8 @@ object DexJarCache {
 }
 
 @Serializable
-data class DexJarCacheMeta(
+data class ApkCacheMeta(
   val canonicalPath: String,
   val posixCTime: Long,
-  val dexJarSha256Sum: String,
+  val apkSha256Sum: String,
 )
-

--- a/kotlin/internal/tool/d8-preserve-manifest/src/main/kotlin/com/squareup/stoic/d8pm/Main.kt
+++ b/kotlin/internal/tool/d8-preserve-manifest/src/main/kotlin/com/squareup/stoic/d8pm/Main.kt
@@ -36,10 +36,10 @@ fun d8PreserveManifest(jarFile: File, apkFile: File, tempDir: File) {
       jarFile.absolutePath
     ).redirectError(ProcessBuilder.Redirect.INHERIT).start().waitFor() == 0)
 
-  ZipOutputStream(FileOutputStream(apkFile)).use { zipOut ->
+  ZipOutputStream(apkFile.outputStream().buffered()).use { zipOut ->
     dexOutDir.listFiles()?.forEach { file ->
       zipOut.putNextEntry(ZipEntry(file.name))
-      FileInputStream(file).use { it.copyTo(zipOut) }
+      file.inputStream().buffered().use { it.copyTo(zipOut) }
       zipOut.closeEntry()
     }
   }

--- a/kotlin/internal/tool/d8-preserve-manifest/src/main/kotlin/com/squareup/stoic/d8pm/Main.kt
+++ b/kotlin/internal/tool/d8-preserve-manifest/src/main/kotlin/com/squareup/stoic/d8pm/Main.kt
@@ -1,10 +1,11 @@
 package com.squareup.stoic.d8pm
 import com.squareup.stoic.bridge.StoicProperties
 import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.nio.file.Files
-import java.util.jar.JarEntry
-import java.util.jar.JarFile
-import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 fun main(args: Array<String>) {
   println("args: ${args.joinToString(", ")}")
@@ -16,46 +17,30 @@ fun main(args: Array<String>) {
   System.err.println("generated: ${dst.absolutePath}")
 }
 
-fun d8PreserveManifest(jarFile: File, dexJarFile: File) {
-  d8PreserveManifest(jarFile, dexJarFile, tempDir = Files.createTempDirectory("d8-preserve-manifest").toFile())
+fun d8PreserveManifest(jarFile: File, apkFile: File) {
+  d8PreserveManifest(jarFile, apkFile, tempDir = Files.createTempDirectory("d8-preserve-manifest").toFile())
 }
 
-fun d8PreserveManifest(jarFile: File, dexJarFile: File, tempDir: File) {
+fun d8PreserveManifest(jarFile: File, apkFile: File, tempDir: File) {
   val androidBuildToolsVersion = StoicProperties.ANDROID_BUILD_TOOLS_VERSION
   val androidHome = System.getenv("ANDROID_HOME") ?: error("Need to set ANDROID_HOME")
   val d8Path = File("$androidHome/build-tools/$androidBuildToolsVersion/d8")
-  val rawDexJar = File(tempDir, "raw.dex.jar")
+  val dexOutDir = File(tempDir, "stoic-dex")
+  dexOutDir.mkdirs()
 
   check(
     ProcessBuilder(
       d8Path.absolutePath,
       "--min-api", StoicProperties.ANDROID_MIN_SDK.toString(),
-      "--output", rawDexJar.absolutePath,
+      "--output", dexOutDir.absolutePath,
       jarFile.absolutePath
     ).start().waitFor() == 0)
 
-  val manifestPath = "META-INF/MANIFEST.MF"
-
-  JarOutputStream(dexJarFile.outputStream().buffered()).use { outputJarStream ->
-    JarFile(rawDexJar).use { dex ->
-      if (dex.getEntry(manifestPath) == null) {
-        JarFile(jarFile).use { original ->
-          val manifestEntry = original.getEntry(manifestPath)
-          if (manifestEntry != null) {
-            outputJarStream.putNextEntry(JarEntry(manifestPath))
-            original.getInputStream(manifestEntry).copyTo(outputJarStream)
-            outputJarStream.closeEntry()
-          }
-        }
-      }
-
-      // 1. Copy all entries from the dex.jar
-      for (entry in dex.entries()) {
-        val newEntry = JarEntry(entry.name)
-        outputJarStream.putNextEntry(newEntry)
-        dex.getInputStream(entry).copyTo(outputJarStream)
-        outputJarStream.closeEntry()
-      }
+  ZipOutputStream(FileOutputStream(apkFile)).use { zipOut ->
+    dexOutDir.listFiles()?.forEach { file ->
+      zipOut.putNextEntry(ZipEntry(file.name))
+      FileInputStream(file).use { it.copyTo(zipOut) }
+      zipOut.closeEntry()
     }
   }
 }

--- a/kotlin/internal/tool/d8-preserve-manifest/src/main/kotlin/com/squareup/stoic/d8pm/Main.kt
+++ b/kotlin/internal/tool/d8-preserve-manifest/src/main/kotlin/com/squareup/stoic/d8pm/Main.kt
@@ -34,7 +34,7 @@ fun d8PreserveManifest(jarFile: File, apkFile: File, tempDir: File) {
       "--min-api", StoicProperties.ANDROID_MIN_SDK.toString(),
       "--output", dexOutDir.absolutePath,
       jarFile.absolutePath
-    ).start().waitFor() == 0)
+    ).redirectError(ProcessBuilder.Redirect.INHERIT).start().waitFor() == 0)
 
   ZipOutputStream(FileOutputStream(apkFile)).use { zipOut ->
     dexOutDir.listFiles()?.forEach { file ->

--- a/kotlin/local.properties
+++ b/kotlin/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sun May 12 15:23:51 PDT 2024
-sdk.dir=/Users/tomm/Library/Android/sdk


### PR DESCRIPTION
Fixes #24

I've done the minimum amount of changes that let me run the `appexitinfo` plugin on my app. 

I also tried to write a custom plugin to test this for my specific use case but couldn't nail the interaction down with suspend functions to make the plugin work correctly, and kept causing native crashes that looked like `Check failed: (gdata->jvmti->SetEventNotificationMode(isEnabled ? JVMTI_ENABLE : JVMTI_DISABLE, JVMTI_EVENT_METHOD_EXIT, thread)) == JVMTI_ERROR_NONE ((gdata->jvmti->SetEventNotificationMode(isEnabled ? JVMTI_ENABLE : JVMTI_DISABLE, JVMTI_EVENT_METHOD_EXIT, thread))=99, JVMTI_ERROR_NONE=0)`.

